### PR TITLE
Add menu modules for full UI

### DIFF
--- a/app/integrations/kobold_cpp.py
+++ b/app/integrations/kobold_cpp.py
@@ -52,9 +52,9 @@ popd
             llm["name"] = name
 
             # ローカルでの新規追加モデルの場合
-            if "file_name" in llm and "urls" not in llm:
-                llm["urls"] = []
-                llm["info_url"] = ""
+            if "file_name" in llm and ("urls" not in llm or not llm.get("urls")):
+                llm["urls"] = llm.get("urls", [])
+                llm["info_url"] = llm.get("info_url", "")
                 continue
 
             # 既存の配布モデルの場合

--- a/app/menu/file_menu.py
+++ b/app/menu/file_menu.py
@@ -1,0 +1,239 @@
+﻿import glob
+import os
+import re
+import shutil
+import time
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+from app.core.path import Path
+
+
+class FileMenu:
+    def __init__(self, form, ctx):
+        self.form = form
+        self.ctx = ctx
+
+        self.menu = tk.Menu(form.win, tearoff=False)
+        self.form.menu_bar.add_cascade(label="ファイル", menu=self.menu)
+        self.menu.configure(postcommand=self.on_menu_open)
+
+        self.form.win.bind("<Control-n>", lambda e: self.new_file())
+        self.form.win.bind("<Control-o>", lambda e: self.open_file())
+        self.form.win.bind("<Control-O>", lambda e: self.open_dir())
+        self.form.win.bind("<Control-s>", lambda e: self.save_file())
+        self.form.win.bind("<Control-S>", lambda e: self.save_all_file())
+        self.form.win.bind("<Control-F4>", lambda e: self.close_file())
+
+    def on_menu_open(self):
+        self.menu.delete(0, tk.END)
+
+        if len(self.ctx["recent_files"]) > 0:  # 最近使ったファイル、のカスケードメニューadd_cascade
+            recent_files = tk.Menu(self.menu, tearoff=False)
+            self.menu.add_cascade(label="最近使ったファイル", menu=recent_files)
+            for file_path in reversed(self.ctx["recent_files"]):
+                if os.path.exists(file_path):
+                    recent_files.add_command(label=file_path, command=lambda fp=file_path: self._open_file(fp))
+                else:
+                    self.ctx["recent_files"].remove(file_path)
+
+        if len(self.ctx["recent_dirs"]) > 0:  # 最近使ったフォルダ、のカスケードメニューadd_cascade
+            recent_dirs = tk.Menu(self.menu, tearoff=False)
+            self.menu.add_cascade(label="最近開いたフォルダ", menu=recent_dirs)
+            for dir_path in reversed(self.ctx["recent_dirs"]):
+                if os.path.exists(dir_path):
+                    recent_dirs.add_command(label=dir_path, command=lambda dp=dir_path: self._open_dir(dp))
+                else:
+                    self.ctx["recent_dirs"].remove(dir_path)
+
+        if (len(self.ctx["recent_files"]) > 0) or (len(self.ctx["recent_dirs"]) > 0):
+            self.menu.add_separator()
+
+        self.menu.add_command(label="新規作成 (Ctrl+N)", command=self.new_file)
+        self.menu.add_command(label="開く (Ctrl+O)", command=self.open_file)
+        self.menu.add_command(label="フォルダを開く (Ctrl+Shift+O)", command=self.open_dir)
+
+        self.menu.add_separator()
+
+        def _set_watch_file(*args):
+            self.ctx["watch_file"] = self.watch_file_var.get()
+
+        self.watch_file_var = tk.BooleanVar(value=self.ctx["watch_file"])
+        self.watch_file_var.trace_add("write", _set_watch_file)
+        self.menu.add_checkbutton(label="ファイル監視", variable=self.watch_file_var)
+
+        self.menu.add_separator()
+
+        self.menu.add_command(label="保存 (Ctrl+S)", command=self.save_file)
+        self.menu.add_command(label="名前を付けて保存", command=self.save_as_file)
+        self.menu.add_command(label="すべて保存 (Ctrl+Shift+S)", command=self.save_all_file)
+
+        self.menu.add_separator()
+
+        self.menu.add_command(label="閉じる (Ctrl+F4)", command=self.close_file)
+        self.menu.add_command(label="すべて閉じる", command=self.close_all_file)
+
+        self.menu.add_separator()
+
+        self.menu.add_command(label="終了 (Alt+F4)", command=self.ctx.finalize)
+
+    def new_file(self):
+        input_area = self.ctx.form.input_area
+        input_area.close_unmodified_new_tab()
+        input_area.open_tab()
+        self.form.update_title()
+
+    def open_file(self):
+        initial_path = self.ctx.form.input_area.get_file_path()
+        if initial_path is None:
+            initial_dir = Path.cwd
+        else:
+            initial_dir = os.path.dirname(initial_path)
+        file_paths = filedialog.askopenfilename(
+            filetypes=[("テキストファイル", "*.txt")], initialdir=initial_dir, multiple=True
+        )
+        if file_paths != "":
+            for file_path in file_paths:
+                self._open_file(file_path)
+
+    def open_dir(self):
+        initial_path = self.ctx.form.input_area.get_file_path()
+        if initial_path is None:
+            initial_dir = Path.cwd
+        else:
+            initial_dir = os.path.dirname(initial_path)
+        dir_path = filedialog.askdirectory(initialdir=initial_dir)
+        if dir_path != "":
+            self._open_dir(dir_path)
+
+    def dnd_file(self, event):
+        file_paths = re.findall(r"\{[^}]*\}|[^ ]+", event.data)
+        file_paths = [file_path.strip("{}") for file_path in file_paths]
+        file_paths.sort()
+        for file_path in file_paths:
+            if file_path.endswith(".txt"):
+                if os.path.exists(file_path):
+                    self._open_file(file_path)
+            elif os.path.isdir(file_path):
+                self._open_dir(file_path)
+        return "break"
+
+    def _open_dir(self, dir_path):
+        txt_files = glob.glob(os.path.join(dir_path, "**", "*.txt"), recursive=True)
+        txt_files.sort()
+
+        for file_path in txt_files:
+            if os.path.exists(file_path):
+                self._open_file(file_path)
+
+        if dir_path in self.ctx["recent_dirs"]:
+            self.ctx["recent_dirs"].remove(dir_path)
+        self.ctx["recent_dirs"].append(dir_path)
+        remove_num = len(self.ctx["recent_dirs"]) - self.ctx["recents"]
+        if remove_num > 0:
+            self.ctx["recent_dirs"] = self.ctx["recent_dirs"][remove_num:]
+
+    def _open_file(self, file_path, func=None):
+        input_area = self.ctx.form.input_area
+        for tab in input_area.tabs:
+            if tab.file_path == file_path:
+                input_area.select_tab(tab)
+                if not self.ask_save(func):
+                    return
+
+        input_area = self.ctx.form.input_area
+        with open(file_path, "r", encoding="utf-8-sig") as f:
+            input_text = f.read()
+        input_area.close_unmodified_new_tab()
+        input_area.open_tab(input_text, file_path)
+        self.form.update_title()
+        self._add_recent_file(file_path)
+
+    def _add_recent_file(self, file_path):
+        if file_path in self.ctx["recent_files"]:
+            self.ctx["recent_files"].remove(file_path)
+        self.ctx["recent_files"].append(file_path)
+        remove_num = len(self.ctx["recent_files"]) - self.ctx["recents"]
+        if remove_num > 0:
+            self.ctx["recent_files"] = self.ctx["recent_files"][remove_num:]
+
+    def save_file(self):
+        input_area = self.ctx.form.input_area
+        file_path = input_area.get_file_path()
+        if file_path is None:
+            return self.save_as_file()
+        self._backup_file(file_path)
+        input_text = input_area.get_text()
+        with open(file_path, "w", encoding="utf-8-sig") as f:
+            f.write(input_text)
+        input_area.set_file(input_text, file_path)
+        self._add_recent_file(file_path)
+        return True
+
+    def save_as_file(self):
+        input_area = self.ctx.form.input_area
+        file_name = f'{time.strftime("%Y%m%d_%H%M%S", time.localtime())}.txt'
+
+        if input_area.get_file_path() is None:
+            initial_dir = Path.cwd
+        else:
+            initial_dir = os.path.dirname(input_area.get_file_path())
+        file_types = [("テキストファイル", "*.txt")]
+        file_path = filedialog.asksaveasfilename(filetypes=file_types, initialdir=initial_dir, initialfile=file_name)
+        if file_path == "":
+            return False
+        if not file_path.endswith(".txt"):
+            file_path += ".txt"
+
+        self._backup_file(file_path)
+        input_text = input_area.get_text()
+        with open(file_path, "w", encoding="utf-8-sig") as f:
+            f.write(input_text)
+        input_area.set_file(input_text, file_path)
+        self.form.update_title()
+        self._add_recent_file(file_path)
+        return True
+
+    def _backup_file(self, file_path):
+        if not os.path.exists(file_path):
+            return
+        YYYYMMDD_HHMMSS = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+        log_file_name = f"{YYYYMMDD_HHMMSS}-{os.path.basename(file_path)}"
+        shutil.copy2(file_path, os.path.join(Path.daily_log, log_file_name))
+
+    def save_all_file(self):
+        input_area = self.ctx.form.input_area
+        init_tab = input_area.tab
+        for tab in input_area.tabs:
+            input_area.select_tab(tab)
+            self.save_file()
+        input_area.select_tab(init_tab)
+
+    def close_file(self):
+        input_area = self.ctx.form.input_area
+        if not self.ask_save():
+            return
+        input_area.close_tab()
+        self.form.update_title()
+
+    def close_all_file(self):
+        input_area = self.ctx.form.input_area
+
+        for tab in reversed(input_area.tabs):
+            input_area.select_tab(tab)
+            self.close_file()
+
+    def ask_save(self, func=None):
+        input_area = self.ctx.form.input_area
+
+        input_text = input_area.get_text()
+        if input_area.get_file_text() == input_text:
+            return True
+        result = messagebox.askyesnocancel("EasyNovelAssistant", "変更内容を保存しますか？")
+        if result is None:
+            return False
+        if result:
+            if func is None:
+                func = self.save_file
+            return func()
+        return True

--- a/app/menu/gen_menu.py
+++ b/app/menu/gen_menu.py
@@ -1,0 +1,93 @@
+﻿import tkinter as tk
+
+
+class GenMenu:
+    def __init__(self, form, ctx):
+        self.form = form
+        self.ctx = ctx
+
+        self.menu = tk.Menu(form.win, tearoff=False)
+        self.form.menu_bar.add_cascade(label="生成", menu=self.menu)
+        self.menu.configure(postcommand=self.on_menu_open)
+
+        self.form.win.bind("<F3>", lambda e: self._enable())
+        self.form.win.bind("<F4>", lambda e: self._disable())
+        self.form.win.bind("<Shift-F5>", lambda e: self._set_enabled(not self.ctx.generator.enabled))
+        self.form.win.bind("<F5>", lambda e: self._abort())
+
+    def _set_enabled(self, enabled):
+        self.ctx.generator.enabled = enabled
+        self.ctx.kobold_cpp.get_model()
+        self.ctx.form.update_title()
+        if not enabled:
+            self.ctx.generator.abort()
+
+    def _enable(self):
+        if not self.ctx.generator.enabled:
+            self._set_enabled(True)
+
+    def _disable(self):
+        if self.ctx.generator.enabled:
+            self._set_enabled(False)
+
+    def _abort(self):
+        self.ctx.generator.abort()
+        self.ctx.style_bert_vits2.abort()
+
+    def on_menu_open(self):
+        self.menu.delete(0, tk.END)
+
+        self.menu.add_command(label="生成を開始 (F3)", command=self._enable)
+
+        self.menu.add_command(label="生成を終了 (F4)", command=self._disable)
+
+        def set_enabled(*args):
+            self._set_enabled(self.enabled_var.get())
+
+        self.enabled_var = tk.BooleanVar(value=self.ctx.generator.enabled)
+        self.enabled_var.trace_add("write", set_enabled)
+        self.menu.add_checkbutton(label="生成の開始/終了 (Shift+F5)", variable=self.enabled_var)
+
+        self.menu.add_command(label="生成を中断 (F5)", command=self.ctx.generator.abort)
+
+        self.menu.add_separator()
+
+        def set_max_length(max_length):
+            self.ctx["max_length"] = max_length
+
+        self.max_length_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(label=f'生成文の長さ: {self.ctx["max_length"]}', menu=self.max_length_menu)
+
+        llm = self.ctx.llm[self.ctx["llm_name"]]
+        max_context_length = min(llm["context_size"], self.ctx["llm_context_size"])
+        for max_length in self.ctx["max_lengths"]:
+            if max_length >= max_context_length:
+                break
+            check_var = tk.BooleanVar(value=self.ctx["max_length"] == max_length)
+            self.max_length_menu.add_checkbutton(
+                label=max_length, variable=check_var, command=lambda gl=max_length, _=check_var: set_max_length(gl)
+            )
+
+        self.temperature_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(
+            label=f'ゆらぎ度合い (Temperature): {self.ctx["temperature"]}', menu=self.temperature_menu
+        )
+
+        def set_temperature(temperature):
+            self.ctx["temperature"] = temperature
+
+        temperatures = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+        for temperature in temperatures:
+            check_var = tk.BooleanVar(value=self.ctx["temperature"] == temperature)
+            self.temperature_menu.add_checkbutton(
+                label=temperature, variable=check_var, command=lambda t=temperature, _=check_var: set_temperature(t)
+            )
+
+        self.menu.add_separator()
+
+        def set_auto_scroll(*args):
+            self.ctx["auto_scroll"] = self.auto_scroll_var.get()
+
+        self.auto_scroll_var = tk.BooleanVar(value=self.ctx["auto_scroll"])
+        self.auto_scroll_var.trace_add("write", set_auto_scroll)
+        self.menu.add_checkbutton(label="自動スクロール", variable=self.auto_scroll_var)

--- a/app/menu/help_menu.py
+++ b/app/menu/help_menu.py
@@ -1,0 +1,62 @@
+﻿import tkinter as tk
+import webbrowser
+
+
+class HelpMenu:
+
+    def __init__(self, form, ctx):
+        self.form = form
+        self.ctx = ctx
+
+        self.menu = tk.Menu(form.win, tearoff=False)
+        self.form.menu_bar.add_cascade(label="ヘルプ", menu=self.menu)
+        self.menu.configure(postcommand=self.on_menu_open)
+
+    def on_menu_open(self):
+        self.menu.delete(0, tk.END)
+
+        sample_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(label="サンプル原典", menu=sample_menu)
+
+        cmd = lambda: self._show_url("https://kakuyomu.jp/works/16818093074043995181")
+        sample_menu.add_command(label="最新AI Claude 3で長編小説執筆支援【GPT-4を超えた!?】", command=cmd)
+
+        cmd = lambda: self._show_url("https://kakuyomu.jp/works/16818093074043995181/episodes/16818093074305285059")
+        sample_menu.add_command(label="↑ のプロンプトまとめ", command=cmd)
+
+        cmd = lambda: self._show_url("https://rentry.org/gpt0721")
+        sample_menu.add_command(label="5ch プロンプトまとめ", command=cmd)
+
+        reference_menu = tk.Menu(self.menu, tearoff=False)
+
+        self.menu.add_cascade(label="参照", menu=reference_menu)
+
+        cmd = lambda: self._show_url("https://github.com/LostRuins/koboldcpp")
+        reference_menu.add_command(label="LostRuins/KoboldCpp", command=cmd)
+        reference_menu.add_separator()
+
+        info_urls = []
+        for llm in self.ctx.llm.values():
+            if llm["info_url"] not in info_urls:
+                info_urls.append(llm["info_url"])
+
+        for info_url in info_urls:
+            cmd = lambda url=info_url: self._show_url(url)
+            parts = info_url.split("/")
+            label = f"{parts[-2]}/{parts[-1]}"
+            reference_menu.add_command(label=label, command=cmd)
+
+        reference_menu.add_separator()
+        self._show_hf_url(reference_menu, "kaunista/kaunista-style-bert-vits2-models")
+        self._show_hf_url(reference_menu, "RinneAi/Rinne_Style-Bert-VITS2")
+
+        self.menu.add_separator()
+        cmd = lambda: self._show_url("https://github.com/Zuntan03/EasyNovelAssistant")
+        self.menu.add_command(label="EasyNovelAssistant", command=cmd)
+
+    def _show_hf_url(self, menu, hf_name):
+        cmd = lambda: self._show_url(f"https://huggingface.co/{hf_name}")
+        menu.add_command(label=hf_name, command=cmd)
+
+    def _show_url(self, url):
+        webbrowser.open(url)

--- a/app/menu/model_menu.py
+++ b/app/menu/model_menu.py
@@ -1,0 +1,99 @@
+﻿import os
+import tkinter as tk
+from tkinter import simpledialog
+
+from app.core.path import Path
+
+
+class ModelMenu:
+    SEPALATER_NAMES = [
+        "LightChatAssistant-4x7B-IQ4_XS",
+    ]
+
+    def __init__(self, form, ctx):
+        self.form = form
+        self.ctx = ctx
+
+        self.menu = tk.Menu(form.win, tearoff=False)
+        self.form.menu_bar.add_cascade(label="モデル", menu=self.menu)
+        self.menu.configure(postcommand=self.on_menu_open)
+
+    def on_menu_open(self):
+        self.menu.delete(0, tk.END)
+
+        def context_label(context_size):
+            llm_name = self.ctx["llm_name"]
+            model_ctx_size = self.ctx.llm[llm_name]["context_size"]
+            if context_size > model_ctx_size:
+                return f"C{model_ctx_size // 1024}K: {context_size} > {model_ctx_size}({llm_name})"
+            return f"C{context_size // 1024}K: {context_size}"
+
+        self.llm_context_size_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(
+            label=f'コンテキストサイズ上限（増やすと VRAM 消費増）: {context_label(self.ctx["llm_context_size"])})',
+            menu=self.llm_context_size_menu,
+        )
+
+        def set_llm_context_size(llm_context_size):
+            self.ctx["llm_context_size"] = llm_context_size
+
+        llm_context_sizes = [2048, 4096, 8192, 16384, 32768, 65536, 131072]
+        for llm_context_size in llm_context_sizes:
+            check_var = tk.BooleanVar(value=self.ctx["llm_context_size"] == llm_context_size)
+            self.llm_context_size_menu.add_checkbutton(
+                label=context_label(llm_context_size),
+                variable=check_var,
+                command=lambda v=llm_context_size, _=check_var: set_llm_context_size(v),
+            )
+
+        self.menu.add_separator()
+
+        categories = {}
+
+        for llm_name in self.ctx.llm:
+            llm = self.ctx.llm[llm_name]
+
+            llm_menu = tk.Menu(self.menu, tearoff=False)
+            name = llm_name
+            context_size = min(llm["context_size"], self.ctx["llm_context_size"]) // 1024
+            if "/" in llm_name:
+                category, name = llm_name.split("/")
+                if category not in categories:
+                    categories[category] = tk.Menu(self.menu, tearoff=False)
+                    self.menu.add_cascade(label=category, menu=categories[category])
+                categories[category].add_cascade(label=f"{name} C{context_size}K", menu=llm_menu)
+            else:
+                self.menu.add_cascade(label=f"{llm_name} C{context_size}K", menu=llm_menu)
+
+            for sep_name in self.SEPALATER_NAMES:
+                if sep_name in name:
+                    self.menu.add_separator()
+
+            llm_path = os.path.join(Path.kobold_cpp, llm["file_name"])
+            if not os.path.exists(llm_path):
+                llm_menu.add_command(
+                    label="ダウンロード（完了まで応答なし、コマンドプロンプトに状況表示）",
+                    command=lambda ln=llm_name: self.ctx.kobold_cpp.download_model(ln),
+                )
+                continue
+
+            max_gpu_layer = llm["max_gpu_layer"]
+            for gpu_layer in self.ctx["llm_gpu_layers"]:
+                if gpu_layer > max_gpu_layer:
+                    llm_menu.add_command(
+                        label=f"L{max_gpu_layer}",
+                        command=lambda ln=llm_name, gl=max_gpu_layer: self.select_model(ln, gl),
+                    )
+                    break
+                else:
+                    llm_menu.add_command(
+                        label=f"L{gpu_layer}", command=lambda ln=llm_name, gl=gpu_layer: self.select_model(ln, gl)
+                    )
+
+    def select_model(self, llm_name, gpu_layer):
+        self.ctx["llm_name"] = llm_name
+        self.ctx["llm_gpu_layer"] = gpu_layer
+        result = self.ctx.kobold_cpp.launch_server()
+        if result is not None:
+            print(result)
+            simpledialog.messagebox.showerror("エラー", result, parent=self.form.win)

--- a/app/menu/sample_menu.py
+++ b/app/menu/sample_menu.py
@@ -1,0 +1,151 @@
+﻿import json
+import os
+import tkinter as tk
+import urllib.request
+import webbrowser
+from urllib.parse import quote
+
+from app.core.path import Path
+
+
+class SampleMenu:
+    URL_TEMPLATE = "https://yyy.wpx.jp/EasyNovelAssistant/sample/{0}"
+
+    def __init__(self, form, ctx):
+        self.form = form
+        self.ctx = ctx
+
+        descs = [
+            {
+                "label": "ユーザー",
+                "mode": "set",
+                "change_mode": {},
+                "path": "user.json",
+                "splitter_names": [],
+            },
+            {
+                "label": "特集テーマ",
+                "mode": "open",
+                "change_mode": {
+                    "サンプル: ": "set",
+                    "テンプレ: ": "set",
+                },
+                "path": "special.json",
+                "splitter_names": ["ゴールシークのリポジトリ"],
+            },
+            {
+                "label": "テンプレート",
+                "mode": "insert",
+                "change_mode": {},
+                "path": "template.json",
+                "splitter_names": [],
+            },
+            {"label": "サンプル", "mode": "set", "change_mode": {}, "path": "sample.json", "splitter_names": []},
+            {
+                "label": "NSFW サンプル",
+                "mode": "set",
+                "change_mode": {},
+                "path": "nsfw.json",
+                "splitter_names": ["妄想ジェネレーター"],
+            },
+            {
+                "label": "読み上げサンプル",
+                "mode": "set",
+                "change_mode": {},
+                "path": "speech.json",
+                "splitter_names": [],
+            },
+            {
+                "label": "作例や記事",
+                "mode": "open",
+                "change_mode": {},
+                "path": "url.json",
+                "splitter_names": [],
+            },
+        ]
+
+        for desc in descs:
+            json_path = os.path.join(Path.sample, desc["path"])
+            if os.path.exists(json_path):
+                menu = tk.Menu(form.win, tearoff=False)
+                form.menu_bar.add_cascade(label=desc["label"], menu=menu)
+
+                menu.configure(postcommand=lambda mn=menu, ds=desc: self.on_menu_open(mn, ds))
+
+    def on_menu_open(self, menu, desc):
+        menu.delete(0, tk.END)
+
+        categories = {}
+
+        json_path = os.path.join(Path.sample, desc["path"])
+        dic = None
+        if os.path.exists(json_path):
+            with open(json_path, "r", encoding="utf-8-sig") as f:
+                dic = json.load(f)
+
+        # if dic is None:
+        #     menu.add_command(label=f'{desc["label"]} をダウンロード', command=lambda p=desc["path"]: self._download(p))
+        #     return
+
+        change_mode = desc["change_mode"]
+        for key in dic:
+            item = dic[key]
+            mode = desc["mode"]
+            if "mode" in item:
+                mode = item["mode"]
+            name = key
+            if "/" in name:
+                category, name = name.split("/")
+                for change_name in change_mode:
+                    if change_name in name:
+                        mode = change_mode[change_name]
+                if category not in categories:
+                    categories[category] = tk.Menu(menu, tearoff=False)
+                    menu.add_cascade(label=category, menu=categories[category])
+                categories[category].add_command(label=name, command=lambda i=item, m=mode: self.on_menu_select(i, m))
+            else:
+                for change_name in change_mode:
+                    if change_name in name:
+                        mode = change_mode[change_name]
+                menu.add_command(label=name, command=lambda i=item, m=mode: self.on_menu_select(i, m))
+
+            if name in desc["splitter_names"]:
+                menu.add_separator()
+
+    # def _download(self, path):
+    #     url = self.URL_TEMPLATE.format(path)
+    #     try:
+    #         with urllib.request.urlopen(url) as res:
+    #             data = res.read()
+    #         with open(os.path.join(Path.sample, path), "wb") as f:
+    #             f.write(data)
+    #             return data
+    #     except Exception as e:
+    #         print(e)
+    #     return None
+
+    def on_menu_select(self, item, mode):
+        if (mode == "set") or (mode == "insert"):
+            if item.startswith("http"):
+                url = quote(item, safe=":/?=")
+                try:
+                    with urllib.request.urlopen(url) as res:
+                        item = res.read().decode("utf-8-sig")
+                except Exception as e:
+                    webbrowser.open(url)
+                    print(f"{e}. {url}")
+                    return
+            if ("{char_name}" in item) or ("{user_name}" in item):
+                item = item.format(char_name=self.ctx["char_name"], user_name=self.ctx["user_name"])
+            if mode == "set":
+                self.ctx.form.input_area.set_text(item)
+            else:
+                self.ctx.form.input_area.insert_text(item)
+        elif mode == "open":
+            if item.startswith("http"):
+                url = quote(item, safe=":/?=")
+                webbrowser.open(url)
+            else:
+                print(f"SampleMenu invalid URL: {mode}, {item}")
+        else:
+            print(f"SampleMenu unknown mode: {mode}, {item}")

--- a/app/menu/setting_menu.py
+++ b/app/menu/setting_menu.py
@@ -1,0 +1,87 @@
+﻿import tkinter as tk
+import tkinter.font as font
+from tkinter import simpledialog
+
+
+class SettingMenu:
+
+    def __init__(self, form, ctx):
+        self.form = form
+        self.ctx = ctx
+
+        self.menu = tk.Menu(form.win, tearoff=False)
+        self.form.menu_bar.add_cascade(label="設定", menu=self.menu)
+        self.menu.configure(postcommand=self._on_menu_open)
+
+    def _on_menu_open(self):
+        self.menu.delete(0, tk.END)
+
+        cmd = lambda: self._set_name("char_name", "キャラ名")
+        self.menu.add_command(label=f'キャラ名: {self.ctx["char_name"]}', command=cmd)
+
+        cmd = lambda: self._set_name("user_name", "ユーザー名")
+        self.menu.add_command(label=f'ユーザー名: {self.ctx["user_name"]}', command=cmd)
+
+        self.menu.add_separator()
+
+        def _set_font(f):
+            self.ctx["text_area_font"] = f
+            self.form.input_area.apply_text_setting()
+            self.form.gen_area.apply_text_setting()
+            self.form.output_area.apply_text_setting()
+
+        font_menu = tk.Menu(self.menu, tearoff=False)
+
+        self.menu.add_cascade(label=f'フォント（↑↓キー利用可）: {self.ctx["text_area_font"]}', menu=font_menu)
+        for font_family in font.families():
+            check_var = tk.BooleanVar(value=self.ctx["text_area_font"] == font_family)
+
+            font_menu.add_checkbutton(
+                label=font_family, variable=check_var, command=lambda f=font_family, _=check_var: _set_font(f)
+            )
+
+        def _set_font_size(fons_size):
+            self.ctx["text_area_font_size"] = fons_size
+            self.form.input_area.apply_text_setting()
+            self.form.gen_area.apply_text_setting()
+            self.form.output_area.apply_text_setting()
+
+        font_size_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(label=f'フォントサイズ: {self.ctx["text_area_font_size"]}', menu=font_size_menu)
+
+        font_sizes = [8, 9, 10, 11, 12, 14, 16, 18, 20, 22, 24, 26, 28, 36, 48, 72]
+        for font_size in font_sizes:
+            check_var = tk.BooleanVar(value=self.ctx["text_area_font_size"] == font_size)
+
+            font_size_menu.add_checkbutton(
+                label=font_size, variable=check_var, command=lambda fs=font_size, _=check_var: _set_font_size(fs)
+            )
+
+        self.menu.add_separator()
+
+        def _set_invert_color():
+            fg = self.ctx["foreground_color"]
+            self.ctx["foreground_color"] = self.ctx["select_background_color"]
+            self.ctx["select_background_color"] = fg
+            sel_fg = self.ctx["select_foreground_color"]
+            self.ctx["select_foreground_color"] = self.ctx["background_color"]
+            self.ctx["background_color"] = sel_fg
+            self.form.input_area.apply_text_setting()
+            self.form.gen_area.apply_text_setting()
+            self.form.output_area.apply_text_setting()
+
+        self.menu.add_command(label="テーマカラーの反転", command=_set_invert_color)
+
+    def _set_name(self, who, who_label):
+        name = self.ctx[who]
+
+        name = simpledialog.askstring(
+            f"{who_label}設定",
+            f"サンプルなどで使用する{who_label}を入力してください。",
+            initialvalue=name,
+            parent=self.form.win,
+        )
+        if name is None:
+            return
+        elif name != "":
+            self.ctx[who] = name

--- a/app/menu/speech_menu.py
+++ b/app/menu/speech_menu.py
@@ -1,0 +1,168 @@
+﻿import os
+import tkinter as tk
+
+from app.core.path import Path
+
+
+class SpeechMenu:
+
+    def __init__(self, form, ctx):
+        self.form = form
+        self.ctx = ctx
+
+        self.menu = tk.Menu(form.win, tearoff=False)
+        self.form.menu_bar.add_cascade(label="読み上げ", menu=self.menu)
+        self.menu.configure(postcommand=self.on_menu_open)
+
+    def on_menu_open(self):
+        self.menu.delete(0, tk.END)
+
+        # 入力欄をすべて読み上げる
+        def speech_all():
+            text = self.ctx.form.input_area.get_comment_removed_text()
+            lines = text.splitlines()
+            for line in lines:
+                self.ctx.style_bert_vits2.generate(line, force=True)
+
+        self.menu.add_command(label="入力欄を読み上げ", command=speech_all)
+
+        self.menu.add_command(label="読み上げを中断 (F5)", command=self.ctx.style_bert_vits2.abort)
+
+        self.menu.add_separator()
+
+        models = self.ctx.style_bert_vits2.models
+        if models is None:
+            models = self.ctx.style_bert_vits2.get_models()
+
+        if models is None:
+            if not os.path.exists(Path.style_bert_vits2):
+                self.menu.add_command(
+                    label="Style-Bert-VITS2 をインストール", command=self.ctx.style_bert_vits2.install
+                )
+            elif not os.path.exists(Path.style_bert_vits2_config):
+                self.menu.add_command(label="Style-Bert-VITS2 のインストール中")
+            else:
+                self.menu.add_command(
+                    label="読み上げサーバーを立ち上げる", command=self.ctx.style_bert_vits2.launch_server
+                )
+
+            def set_style_bert_vits2_gpu(*args):
+                self.ctx["style_bert_vits2_gpu"] = self.gpu_var.get()
+
+            self.gpu_var = tk.BooleanVar(value=self.ctx["style_bert_vits2_gpu"])
+            self.gpu_var.trace_add("write", set_style_bert_vits2_gpu)
+            self.menu.add_checkbutton(label="GPU を使用する", variable=self.gpu_var)
+            return
+
+        def set_middle_click(*args):
+            self.ctx["middle_click_speech"] = self.middle_click_var.get()
+
+        self.middle_click_var = tk.BooleanVar(value=self.ctx["middle_click_speech"])
+        self.middle_click_var.trace_add("write", set_middle_click)
+        self.menu.add_checkbutton(label="中クリック読み上げ", variable=self.middle_click_var)
+
+        def set_auto_speech_char(*args):
+            self.ctx["auto_speech_char"] = self.auto_speech_char_var.get()
+
+        self.auto_speech_char_var = tk.BooleanVar(value=self.ctx["auto_speech_char"])
+        self.auto_speech_char_var.trace_add("write", set_auto_speech_char)
+        self.menu.add_checkbutton(label=f'{self.ctx["char_name"]} 自動読み上げ', variable=self.auto_speech_char_var)
+
+        def set_auto_speech_user(*args):
+            self.ctx["auto_speech_user"] = self.auto_speech_user_var.get()
+
+        self.auto_speech_user_var = tk.BooleanVar(value=self.ctx["auto_speech_user"])
+        self.auto_speech_user_var.trace_add("write", set_auto_speech_user)
+        self.menu.add_checkbutton(label=f'{self.ctx["user_name"]} 自動読み上げ', variable=self.auto_speech_user_var)
+
+        def set_auto_speech_other(*args):
+            self.ctx["auto_speech_other"] = self.auto_speech_other_var.get()
+
+        self.auto_speech_other_var = tk.BooleanVar(value=self.ctx["auto_speech_other"])
+        self.auto_speech_other_var.trace_add("write", set_auto_speech_other)
+        self.menu.add_checkbutton(label="その他 自動読み上げ", variable=self.auto_speech_other_var)
+
+        self.menu.add_separator()
+
+        self.volume_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(label=f'読み上げ音量: {self.ctx["speech_volume"]}%', menu=self.volume_menu)
+
+        def set_speech_volume(volume):
+            self.ctx["speech_volume"] = volume
+
+        volumes = [100, 90, 80, 70, 60, 50, 40, 30, 20, 10, 0]
+        for volume in volumes:
+            check_var = tk.BooleanVar(value=self.ctx["speech_volume"] == volume)
+            self.volume_menu.add_checkbutton(
+                label=f"{volume}%", variable=check_var, command=lambda v=volume, _=check_var: set_speech_volume(v)
+            )
+
+        self.speed_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(label=f'読み上げ速度: {self.ctx["speech_speed"]}倍', menu=self.speed_menu)
+
+        def set_speech_speed(speed):
+            self.ctx["speech_speed"] = speed
+
+        speeds = [2.0, 1.75, 1.5, 1.25, 1.0, 0.75, 0.5]
+        for speed in speeds:
+            check_var = tk.BooleanVar(value=self.ctx["speech_speed"] == speed)
+            self.speed_menu.add_checkbutton(
+                label=f"{speed}倍", variable=check_var, command=lambda s=speed, _=check_var: set_speech_speed(s)
+            )
+
+        self.interval_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(label=f'読み上げ間隔: {self.ctx["speech_interval"]}秒', menu=self.interval_menu)
+
+        def set_speech_interval(interval):
+            self.ctx["speech_interval"] = interval
+
+        intervals = [3.0, 2.0, 1.5, 1.0, 0.8, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
+        for interval in intervals:
+            check_var = tk.BooleanVar(value=self.ctx["speech_interval"] == interval)
+            self.interval_menu.add_checkbutton(
+                label=f"{interval}秒",
+                variable=check_var,
+                command=lambda i=interval, _=check_var: set_speech_interval(i),
+            )
+
+        self.menu.add_separator()
+
+        def set_char_voice(voice_name):
+            self.ctx["char_voice"] = voice_name
+
+        self.char_voice_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(
+            label=f'{self.ctx["char_name"]} の声: {self.ctx["char_voice"]}', menu=self.char_voice_menu
+        )
+
+        for voice_name in models:
+            check_var = tk.BooleanVar(value=self.ctx["char_voice"] == voice_name)
+            self.char_voice_menu.add_checkbutton(
+                label=voice_name, variable=check_var, command=lambda vn=voice_name, _=check_var: set_char_voice(vn)
+            )
+
+        def set_user_voice(voice_name):
+            self.ctx["user_voice"] = voice_name
+
+        self.user_voice_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(
+            label=f'{self.ctx["user_name"]} の声: {self.ctx["user_voice"]}', menu=self.user_voice_menu
+        )
+
+        for voice_name in models:
+            check_var = tk.BooleanVar(value=self.ctx["user_voice"] == voice_name)
+            self.user_voice_menu.add_checkbutton(
+                label=voice_name, variable=check_var, command=lambda vn=voice_name, _=check_var: set_user_voice(vn)
+            )
+
+        def set_other_voice(voice_name):
+            self.ctx["other_voice"] = voice_name
+
+        self.other_voice_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(label=f'その他の声: {self.ctx["other_voice"]}', menu=self.other_voice_menu)
+
+        for voice_name in models:
+            check_var = tk.BooleanVar(value=self.ctx["other_voice"] == voice_name)
+            self.other_voice_menu.add_checkbutton(
+                label=voice_name, variable=check_var, command=lambda vn=voice_name, _=check_var: set_other_voice(vn)
+            )

--- a/app/menu/tool_menu.py
+++ b/app/menu/tool_menu.py
@@ -1,0 +1,108 @@
+﻿import os
+import subprocess
+import tkinter as tk
+import webbrowser
+from sys import platform
+
+from app.core.path import Path
+
+
+class ToolMenu:
+
+    def __init__(self, form, ctx):
+        self.form = form
+        self.ctx = ctx
+
+        self.menu = tk.Menu(form.win, tearoff=False)
+        self.form.menu_bar.add_cascade(label="ツール", menu=self.menu)
+        self.menu.configure(postcommand=self._on_menu_open)
+
+    def _on_menu_open(self):
+        self.menu.delete(0, tk.END)
+
+        self.menu.add_command(label="(New!) 動画の作成", command=self.ctx.movie_maker.make)
+
+        def set_subtitles(*args):
+            self.ctx["mov_subtitles"] = self.subtitles_var.get()
+
+        self.subtitles_var = tk.BooleanVar(value=self.ctx["mov_subtitles"])
+        self.subtitles_var.trace_add("write", set_subtitles)
+        self.menu.add_checkbutton(label="動画に字幕を追加", variable=self.subtitles_var)
+
+        def set_resize(resize):
+            self.ctx["mov_resize"] = resize
+
+        self.resize_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(label=f'動画の長辺リサイズ: {self.ctx["mov_resize"]}px', menu=self.resize_menu)
+
+        for resize in [1920, 1900, 1600, 1440, 1200, 1024, 0]:
+            check_var = tk.BooleanVar(value=self.ctx["mov_resize"] == resize)
+            cmd = lambda rs=resize, _=check_var: set_resize(rs)
+            self.resize_menu.add_checkbutton(label=f"{resize}px", variable=check_var, command=cmd)
+
+        def set_crf(crf):
+            self.ctx["mov_crf"] = crf
+
+        self.crf_menu = tk.Menu(self.menu, tearoff=False)
+        self.menu.add_cascade(label=f'動画の品質: CRF {self.ctx["mov_crf"]}', menu=self.crf_menu)
+
+        for crf in [38, 32, 26, 20]:
+            check_var = tk.BooleanVar(value=self.ctx["mov_crf"] == crf)
+            cmd = lambda cr=crf, _=check_var: set_crf(cr)
+            self.crf_menu.add_checkbutton(label=f"CRF {crf}", variable=check_var, command=cmd)
+
+        def set_volume_adjust(*args):
+            self.ctx["mov_volume_adjust"] = self.volume_adjust_var.get()
+
+        self.volume_adjust_var = tk.BooleanVar(value=self.ctx["mov_volume_adjust"])
+        self.volume_adjust_var.trace_add("write", set_volume_adjust)
+        self.menu.add_checkbutton(label="動画の音量を 読み上げ音量 で調整", variable=self.volume_adjust_var)
+
+        def set_tempo_adjust(*args):
+            self.ctx["mov_tempo_adjust"] = self.tempo_adjust_var.get()
+
+        self.tempo_adjust_var = tk.BooleanVar(value=self.ctx["mov_tempo_adjust"])
+        self.tempo_adjust_var.trace_add("write", set_tempo_adjust)
+        self.menu.add_checkbutton(label="動画の速度を 読み上げ速度 で調整", variable=self.tempo_adjust_var)
+
+        self.menu.add_separator()
+
+        self.menu.add_command(label="KoboldCpp", command=self._run_kobold_cpp)
+
+        if os.path.exists(Path.style_bert_vits2_config):
+            self.menu.add_separator()
+            self.menu.add_command(
+                label="Style-Bert-VITS2 音声生成とモデル学習",
+                command=lambda: self._run_style_bert_vits2(Path.style_bert_vits2_app, "app.py"),
+            )
+            self.menu.add_command(
+                label="Style-Bert-VITS2 音声エディタ",
+                command=lambda: self._run_style_bert_vits2(
+                    Path.style_bert_vits2_editor, "server_editor.py --inbrowser"
+                ),
+            )
+
+            self.menu.add_separator()
+            url = "https://booth.pm/ja/search/Style-Bert-VITS2"
+            self.menu.add_command(label="BOOTH (Style-Bert-VITS2)", command=lambda: webbrowser.open(url))
+            url = "https://booth.pm/ja/items/5511738"
+            self.menu.add_command(label="黄琴まひろ (V3-JP-T)", command=lambda: webbrowser.open(url))
+            url = "https://booth.pm/ja/items/5566669"
+            self.menu.add_command(label="女子大生音声モデル", command=lambda: webbrowser.open(url))
+            url = "https://huggingface.co/ayousanz/tsukuyomi-chan-style-bert-vits2-model"
+            self.menu.add_command(label="つくよみちゃん 音声モデル", command=lambda: webbrowser.open(url))
+
+    def _run_kobold_cpp(self, *args):
+        if platform == "win32":
+            command = ["start", "cmd", "/c"]
+            command.append(f"{Path.kobold_cpp_win} || pause")
+            subprocess.run(command, cwd=Path.kobold_cpp, shell=True)
+        else:
+            subprocess.Popen(f"{Path.kobold_cpp_linux}", cwd=Path.kobold_cpp, shell=True)
+
+    def _run_style_bert_vits2(self, bat, py):
+        if platform == "win32":
+            subprocess.run(["start", "cmd", "/c", f"{bat} || pause"], cwd=Path.style_bert_vits2, shell=True)
+        else:
+            python = os.path.join(Path.style_bert_vits2, "venv", "Scripts", "python")
+            subprocess.Popen(f"{python} {py}", cwd=Path.style_bert_vits2, shell=True)

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -5,13 +5,15 @@ User Interface modules for EasyNovelAssistant
 """
 
 from .form import Form
+from .headless_form import HeadlessForm
 from .input_area import InputArea
 from .output_area import OutputArea
 from .gen_area import GenArea
 
 __all__ = [
     'Form',
+    'HeadlessForm',
     'InputArea',
     'OutputArea',
     'GenArea'
-] 
+]

--- a/app/ui/headless_form.py
+++ b/app/ui/headless_form.py
@@ -1,0 +1,8 @@
+class HeadlessForm:
+    def __init__(self, ctx):
+        self.win = None
+        self.input_area = type('obj', (), {'open_tab': lambda *a, **k: None, 'update': lambda *a, **k: None})()
+
+    def run(self):
+        pass
+


### PR DESCRIPTION
## Summary
- add the missing menu modules from upstream so the GUI can display menus again
- fix imports inside the new menu modules
- keep headless support via `HeadlessForm`

## Testing
- `pytest -q`
- `ENA_HEADLESS=1 python easy_novel_assistant.py`


------
https://chatgpt.com/codex/tasks/task_e_68436cb8d7148325821da83428dc55ed