### PR TITLE
Add menu option to download GGUF model from URL

### DIFF
--- a/EasyNovelAssistant/src/kobold_cpp.py
+++ b/EasyNovelAssistant/src/kobold_cpp.py
@@ -109,6 +109,12 @@ popd
                 return f"{llm_name} のダウンロードに失敗しました。\n{curl_cmd}"
         return None
 
+    def download_url(self, url):
+        curl_cmd = f"curl -k -LO {url}"
+        if subprocess.run(curl_cmd, shell=True, cwd=Path.kobold_cpp).returncode != 0:
+            return f"モデルのダウンロードに失敗しました。\n{curl_cmd}"
+        return None
+
     def launch_server(self):
         loaded_model = self.get_model()
         if loaded_model is not None:


### PR DESCRIPTION
## Summary
- let KoboldCpp download a single GGUF URL
- allow model download directly from HuggingFace URL via the model menu

## Testing
- `python3 -m py_compile EasyNovelAssistant/src/kobold_cpp.py EasyNovelAssistant/src/menu/model_menu.py`

------
https://chatgpt.com/codex/tasks/task_e_6856376c90648325adec70a125ae2313