### PR TITLE
feat(app): add H-drive EasySdxlWebUi launcher

### DIFF
--- a/EasyNovelAssistant/tests/test_uv_project.py
+++ b/EasyNovelAssistant/tests/test_uv_project.py
@@ -24,6 +24,17 @@ def test_uv_run_bat_launches_same_app_entrypoint():
     assert "EasyNovelAssistant\\src\\easy_novel_assistant.py" in content
 
 
+def test_combined_easy_sdxl_uv_launcher_starts_webui_and_app():
+    bat_path = PROJECT_ROOT / "Run-EasyNovelAssistant-EasySdxlWebUi-uv.bat"
+    content = bat_path.read_text(encoding="utf-8")
+
+    assert "EASY_SDXL_WEBUI_DIR" in content
+    assert "H:\\EasySdxlWebUi" in content
+    assert "SdxlWebUi-forge.bat" in content
+    assert "--api" in content
+    assert "uv run python EasyNovelAssistant\\src\\easy_novel_assistant.py" in content
+
+
 def test_setup_uses_uv_sync_instead_of_requirements_install():
     setup_bat = (PROJECT_ROOT / "EasyNovelAssistant" / "setup" / "Setup-EasyNovelAssistant.bat").read_text(
         encoding="utf-8"

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@
 
 依存関係は `pyproject.toml` に集約しています。Windowsでは `Run-EasyNovelAssistant-uv.bat` から `uv run` で起動できます。既存のインストール処理も `uv sync --active --no-dev` でアプリ依存を同期します。
 
+EasySdxlWebUi と一緒に起動する場合は `Run-EasyNovelAssistant-EasySdxlWebUi-uv.bat` を使えます。既定では `H:\EasySdxlWebUi` を探し、見つからない場合は `EASY_SDXL_WEBUI_DIR` で指定した展開先を使います。Forge版を `--api` 付きで起動してから EasyNovelAssistant を `uv run` で起動します。
+
 **次のステップは [はじめての生成](https://github.com/Zuntan03/EasyNovelAssistant/wiki/%E3%81%AF%E3%81%98%E3%82%81%E3%81%A6%E3%81%AE%E7%94%9F%E6%88%90) です。**
 
 ## 最近の更新

--- a/Run-EasyNovelAssistant-EasySdxlWebUi-uv.bat
+++ b/Run-EasyNovelAssistant-EasySdxlWebUi-uv.bat
@@ -1,0 +1,35 @@
+@echo off
+chcp 65001 > NUL
+pushd %~dp0
+
+if "%EASY_SDXL_WEBUI_DIR%"=="" (
+  if exist H:\EasySdxlWebUi\SdxlWebUi-forge.bat (
+    set "EASY_SDXL_WEBUI_DIR=H:\EasySdxlWebUi"
+  ) else (
+    set "EASY_SDXL_WEBUI_DIR=%~dp0EasySdxlWebUi"
+  )
+)
+
+if not exist "%EASY_SDXL_WEBUI_DIR%\SdxlWebUi-forge.bat" (
+  echo EasySdxlWebUi が見つかりません: %EASY_SDXL_WEBUI_DIR%
+  echo EASY_SDXL_WEBUI_DIR に EasySdxlWebUi の展開先を指定してください。
+  pause
+  popd
+  exit /b 1
+)
+
+where uv > NUL 2> NUL
+if %errorlevel% neq 0 (
+  echo uv が見つかりません。https://docs.astral.sh/uv/ を参考に uv をインストールしてください。
+  pause
+  popd
+  exit /b 1
+)
+
+set DISABLE_LISTEN_AUTOLAUNCH=1
+start "EasySdxlWebUi Forge API" /D "%EASY_SDXL_WEBUI_DIR%" "%EASY_SDXL_WEBUI_DIR%\SdxlWebUi-forge.bat" --api
+
+uv run python EasyNovelAssistant\src\easy_novel_assistant.py
+if %errorlevel% neq 0 ( pause & popd & exit /b 1 )
+
+popd


### PR DESCRIPTION
﻿## Summary
- add a combined uv launcher that starts H:\EasySdxlWebUi Forge with --api and then starts EasyNovelAssistant
- allow overriding the EasySdxlWebUi location with EASY_SDXL_WEBUI_DIR
- document the combined launcher and cover it with a uv project test

## Test Plan
- uvx --from uv==0.11.19 uv run --python 3.12 --group dev python -m pytest EasyNovelAssistant\tests
- uvx --from uv==0.11.19 uv run --python 3.12 python -m py_compile EasyNovelAssistant\src\easy_novel_assistant.py EasyNovelAssistant\src\form.py EasyNovelAssistant\src\generator.py EasyNovelAssistant\src\image_manager.py EasyNovelAssistant\src\menu\image_menu.py EasyNovelAssistant\src\menu\gen_menu.py EasyNovelAssistant\src\context.py EasyNovelAssistant\src\path.py
